### PR TITLE
v0.2: Reduced the image of the software

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim
+FROM python:3.8-slim-buster
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -7,21 +7,24 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
-#Environment variables
+# Environment variables
 ENV OXYGEN_HOST="https://hvac-simulator-a23-y2kpq.ondigitalocean.app"
 ENV OXYGEN_TOKEN="QWNTDxtJzo"
 
-# Install pip requirements
-COPY requirements.txt .
-RUN python -m pip install -r requirements.txt
+# Install pip requirements and clean up in a single RUN command
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gcc libc-dev && \
+    python -m pip install -r requirements.txt && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    rm -rf /var/lib/apt/lists/* && \
+    adduser -u 5678 --disabled-password --gecos "" appuser && \
+    chown -R appuser /app
+
+USER appuser
 
 WORKDIR /app
 COPY . /app
-
-# Creates a non-root user with an explicit UID and adds permission to access the /app folder
-# For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
-RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
-USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
 CMD ["python", "src/main.py"]


### PR DESCRIPTION
# Release Summary
The dockerfile has been modified to reduce the image of OxygenCS software.

## Deployment Instructions
The workflow will automatically push the image to DockerHub. It can be downloaded from there the image and use it alongside with the image of the database MariaDB.

# How Has This Been Tested?
Tested locally, we will see now the results using the github workflow.

# Checklist:

- [x] The code follows project style guidelines
- [ ] Extensive testing has been performed on this release
- [ ] Documentation has been updated or created as needed
- [x] The version number or release name has been updated
- [x] All planned changes for this release have been completed
- [x] Any critical issues or regressions have been addressed and resolved
